### PR TITLE
/listgroups only for admin

### DIFF
--- a/src/course_bot/general.clj
+++ b/src/course_bot/general.clj
@@ -38,9 +38,11 @@
                       msg (str group " group:\n" (str/join "\n" studs))]
                   (talk/send-text token id msg))))))))
 
-(defn listgroups-talk [db {token :token}]
+(defn listgroups-talk [db {token :token :as conf}]
   (talk/def-command db "listgroups" "send me group list know by the bot"
-    (fn [tx {{id :id} :from}] (send-list-groups tx token id) tx)))
+    (fn [tx {{id :id} :from}]
+        (assert-admin tx conf id)
+        (send-list-groups tx token id) tx)))
 
 (defn start-talk [db {token :token groups-raw :groups allow-restart :allow-restart}]
   (let [groups (-> groups-raw keys set)]

--- a/test/course_bot/general_test.clj
+++ b/test/course_bot/general_test.clj
@@ -47,11 +47,16 @@
         (is (= "Bot Botovich" (codax/get-at! db [1 :name])))
         (is (some? (codax/get-at! db [1 :reg-date]))))
 
-      (testing "group list"
-        (talk "/listgroups")
-        (tt/match-text *chat
+      (testing "group list for admin"
+        (talk 0 "/listgroups")
+        (tt/match-text *chat 0
                        "gr1 group:"
                        "1) Bot Botovich (@, 1)"))
+
+      (testing "group list"
+        (talk 1 "/listgroups")
+        (tt/match-text *chat 1
+                       "That action requires admin rights."))
 
       (testing "simple-report"
         (talk 0 "/report")


### PR DESCRIPTION
The `/listgroups` command gives out personal information (surname, first name, patronymic, **Telegram ID and username**) of all students to any bot user. 

The fix allows it to be performed only by the admin.

Деев Роман Александрович P33102