### PR TITLE
fix(quiz): sort quizzes output correctly

### DIFF
--- a/conf-example/csa-2023.edn
+++ b/conf-example/csa-2023.edn
@@ -10,4 +10,5 @@
  :essay1 [:inline "essay1.edn"]
  :quiz {:test-quiz [:inline "quiz/test-quiz.edn"]
         :test-quiz-2 [:inline "quiz/test-quiz-2.edn"]
-        :test-quiz-3 [:inline "quiz/test-quiz-3.edn"]}}
+        :test-quiz-3 [:inline "quiz/test-quiz-3.edn"]
+        :test-quiz-10 [:inline "quiz/test-quiz-10.edn"]}}

--- a/conf-example/quiz/test-quiz-10.edn
+++ b/conf-example/quiz/test-quiz-10.edn
@@ -1,0 +1,9 @@
+{:name "Test quiz 10"
+ :ignore-in-score true
+ :questions
+ [{:ask "Q1"
+   :options [{:text "a1"}
+             {:text "a2" :correct true}]}
+  {:ask "Q2"
+   :options [{:text "a3" :correct true}
+             {:text "a4"}]}]}

--- a/src/course_bot/quiz.clj
+++ b/src/course_bot/quiz.clj
@@ -108,14 +108,14 @@
   (swap! *current-quiz assoc :stopping true)
   (codax/assoc-at tx [:quiz :current] nil))
 
-(defn get-longest-digits-seq [string] (apply max (conj (map count (re-seq #"\d+" string)) 0)))
-(defn find-longest-digits-seq-in-array [array] (apply max (map get-longest-digits-seq array)))
+(defn get-longest-digits-seq [string] (apply max 0 (map count (re-seq #"\d+" string))))
+(defn find-longest-digits-seq-in-list [list] (apply max (map get-longest-digits-seq list)))
 
-(defn prepend-leading-zeros [s, total-digits-count]
+(defn prepend-leading-zeros [s total-digits-count]
   (str/replace s #"\d+" #(format (str "%0" total-digits-count "d") (parse-long %))))
 
 (defn sort-map-by-digits-in-key [m]
-  (let [digits (find-longest-digits-seq-in-array (map (fn [[k _]] (name k)) m))]
+  (let [digits (find-longest-digits-seq-in-list (map (fn [[k _]] (name k)) m))]
     (sort-by (fn [[k _]] (prepend-leading-zeros (name k) digits)) m)))
 
 (defn startquiz-talk [db {token :token :as conf}]
@@ -131,7 +131,7 @@
                      quiz (-> conf :quiz (get quiz-key))]
                  (when-not quiz-key
                    (let [quizs (->> (-> conf :quiz)
-                                    (sort-map-by-digits-in-key)
+                                    sort-map-by-digits-in-key
                                     (map (fn [[k v]] (str "- " (name k) " (" (-> v :name) ")"))))]
                      (talk/send-text token id (str (tr :quiz/available-quizzes)
                                                    (str/join "\n" quizs)))

--- a/test/course_bot/quiz_test.clj
+++ b/test/course_bot/quiz_test.clj
@@ -39,7 +39,8 @@
                     (tt/unlines "Available quizzes:"
                                 "- test-quiz (Test quiz)"
                                 "- test-quiz-2 (Test quiz 2)"
-                                "- test-quiz-3 (Test quiz 3)")))
+                                "- test-quiz-3 (Test quiz 3)"
+                                "- test-quiz-10 (Test quiz 10)")))
 
       (is (answers? (talk 0 "/startquiz test-quiz")
                     "Are you sure to run 'Test quiz' quiz?"))


### PR DESCRIPTION
fixes: #72 

Added quiz-10 to test that now sort works as expected. This implementation extracts a number from quiz name and sorts quizzes by the extracted value. If the name doesn't contain a number i.e `test-quiz`, 0 is mapped to it so the has the highest priority. 

Any suggestions or improvements are welcome :smiley: 

Soloviev Pavel P33302