### PR TITLE
Fix essay score rounding to make it more positive

### DIFF
--- a/src/course_bot/essay.clj
+++ b/src/course_bot/essay.clj
@@ -357,20 +357,22 @@
             str
             (str/replace #"\." ","))))))
 
+(defn calculate-essay-score [scores]
+  (-> (/ (apply + scores) (count scores))
+      float
+      Math/floor
+      int
+      (#(- 4 %)) ; 3 (max score) = 4 - 1; 1 (min score) = 4 - 3
+      (+ 1) ; + 1 to get actual score
+      ))
+
 (defn essay-score "hardcoded: rank + 1" [essay-code]
   (fn [_tx data id]
     (let [essay-uploaded? (-> data (get id) :essays (get essay-code) :text nil? not)
           reviews (-> data (get id) :essays (get essay-code) :received-review)
           scores (->> reviews (map :rank))]
       (cond (not (empty? scores))
-            (-> (/ (apply + scores) (count scores))
-                float
-                Math/ceil
-                int
-                (#(- 4 %)) ; 3 (max score) = 4 - 1; 1 (min score) = 4 - 3
-                (+ 1) ; + 1 to get actual score
-                )
-
+            (calculate-essay-score scores)
             essay-uploaded? 1
 
             :else 0))))

--- a/test/course_bot/essay_test.clj
+++ b/test/course_bot/essay_test.clj
@@ -476,3 +476,11 @@
 
           (is (= ["Uploading (yes/no)?"]
                  (tt/history *chat :user-id 7 :number 1))))))))
+
+(deftest essay-calculate-score-test
+  (testing "calculate a score based on 3 reviews"
+    (is (= 4 (essay/calculate-essay-score [1 1 2])))
+    (is (= 4 (essay/calculate-essay-score [1 2 2])))
+    (is (= 3 (essay/calculate-essay-score [1 2 3])))
+    (is (= 3 (essay/calculate-essay-score [2 3 3])))
+    (is (= 2 (essay/calculate-essay-score [3 3 3])))))


### PR DESCRIPTION
fixes: #110

Replaced `ceil` with `floor` so the result of subtraction from `4` is rounded up. Also, added a few test-cases to show the expected results.

Soloviev Pavel, P33302